### PR TITLE
feat: add 402 section with L402, x402 and MPP

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@getalby/bitcoin-connect-react": "^3.12.2",
-    "@getalby/lightning-tools": "^6.1.0",
+    "@getalby/lightning-tools": "^8.1.0",
     "@getalby/sdk": "^7.0.0",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/components/402/index.ts
+++ b/src/components/402/index.ts
@@ -1,2 +1,3 @@
 export { L402FetchScenario } from "./l402-fetch";
 export { X402FetchScenario } from "./x402-fetch";
+export { MPPFetchScenario } from "./mpp-fetch";

--- a/src/components/402/index.ts
+++ b/src/components/402/index.ts
@@ -1,0 +1,2 @@
+export { L402FetchScenario } from "./l402-fetch";
+export { X402FetchScenario } from "./x402-fetch";

--- a/src/components/402/l402-fetch.tsx
+++ b/src/components/402/l402-fetch.tsx
@@ -1,0 +1,342 @@
+import { useState } from "react";
+import { Copy, Loader2, ShieldCheck } from "lucide-react";
+import { fetch402, Invoice } from "@getalby/lightning-tools";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useWalletStore, useTransactionStore } from "@/stores";
+import { WALLET_PERSONAS } from "@/types";
+
+const PROXY_BASE_URL = "https://402-proxy.albylabs.com/l402";
+const DEFAULT_PROTECTED_URL = "https://example.com";
+const DEFAULT_PRICE_SATS = 1;
+
+export function L402FetchScenario() {
+  const { areAllWalletsConnected } = useWalletStore();
+  const allConnected = areAllWalletsConnected(["alice", "bob"]);
+
+  const [protectedUrl, setProtectedUrl] = useState(DEFAULT_PROTECTED_URL);
+  const [priceSats, setPriceSats] = useState(DEFAULT_PRICE_SATS);
+
+  if (!allConnected) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <AlicePanel
+        protectedUrl={protectedUrl}
+        priceSats={priceSats}
+        onProtectedUrlChange={setProtectedUrl}
+        onPriceSatsChange={setPriceSats}
+      />
+      <BobPanel protectedUrl={protectedUrl} priceSats={priceSats} />
+    </div>
+  );
+}
+
+interface AlicePanelProps {
+  protectedUrl: string;
+  priceSats: number;
+  onProtectedUrlChange: (url: string) => void;
+  onPriceSatsChange: (sats: number) => void;
+}
+
+function AlicePanel({
+  protectedUrl,
+  priceSats,
+  onProtectedUrlChange,
+  onPriceSatsChange,
+}: AlicePanelProps) {
+  const { getWallet } = useWalletStore();
+  const aliceWallet = getWallet("alice");
+  const [copied, setCopied] = useState(false);
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleCopy = () => {
+    if (!endpointUrl) return;
+    navigator.clipboard.writeText(endpointUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.alice.emoji}</span>
+          <span>Alice: Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Alice's NWC connection is embedded in the endpoint URL. When Bob
+          fetches the resource, the proxy uses her wallet to create a Lightning
+          invoice for the configured price.
+        </p>
+
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              Protected URL
+            </label>
+            <Input
+              value={protectedUrl}
+              onChange={(e) => onProtectedUrlChange(e.target.value)}
+              placeholder="https://example.com"
+              className="font-mono text-xs h-8"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground mr-2">
+              Price (sats)
+            </label>
+            <Input
+              type="number"
+              min={1}
+              value={priceSats}
+              onChange={(e) =>
+                onPriceSatsChange(Math.max(1, parseInt(e.target.value) || 1))
+              }
+              className="font-mono text-xs h-8 w-28"
+            />
+          </div>
+        </div>
+
+        {endpointUrl ? (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground">
+              402 Endpoint URL
+            </label>
+            <div className="relative rounded-lg bg-muted p-3 pr-10">
+              <p className="break-all font-mono text-xs leading-relaxed">
+                {endpointUrl}
+              </p>
+              <button
+                onClick={handleCopy}
+                className="absolute right-2 top-2 rounded p-1 hover:bg-background"
+                title="Copy URL"
+              >
+                <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            </div>
+            {copied && (
+              <p className="text-xs text-green-600 dark:text-green-400">
+                Copied to clipboard
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-yellow-50 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+            Alice's wallet is not connected.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface BobPanelProps {
+  protectedUrl: string;
+  priceSats: number;
+}
+
+function BobPanel({ protectedUrl, priceSats }: BobPanelProps) {
+  const [isFetching, setIsFetching] = useState(false);
+  const [responseBody, setResponseBody] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { getNWCClient, getWallet, setWalletBalance } = useWalletStore();
+  const {
+    addTransaction,
+    updateTransaction,
+    addFlowStep,
+    updateFlowStep,
+    addBalanceSnapshot,
+  } = useTransactionStore();
+
+  const aliceWallet = getWallet("alice");
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleFetch = async () => {
+    if (!endpointUrl) return;
+
+    const bobClient = getNWCClient("bob");
+    if (!bobClient) return;
+
+    setIsFetching(true);
+    setError(null);
+    setResponseBody(null);
+
+    const txId = addTransaction({
+      type: "payment_sent",
+      status: "pending",
+      fromWallet: "bob",
+      toWallet: "alice",
+      amount: 0,
+      description: `402 fetch: ${protectedUrl}`,
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    const requestFlowStepId = addFlowStep({
+      fromWallet: "bob",
+      toWallet: "alice",
+      label: "Fetching resource...",
+      direction: "left",
+      status: "pending",
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    let payFlowStepId = "";
+
+    try {
+      const wallet = {
+        payInvoice: async (args: { invoice: string }) => {
+          const invoiceObj = new Invoice({ pr: args.invoice });
+          const amountSats = invoiceObj.satoshi ?? priceSats;
+
+          updateTransaction(txId, { amount: amountSats });
+
+          payFlowStepId = addFlowStep({
+            fromWallet: "bob",
+            toWallet: "alice",
+            label: `Paying ${amountSats} sat invoice...`,
+            direction: "left",
+            status: "pending",
+          });
+
+          updateFlowStep(requestFlowStepId, {
+            label: "402 received — paying invoice...",
+            direction: "right",
+            status: "success",
+          });
+
+          const result = await bobClient.payInvoice({ invoice: args.invoice });
+          return { preimage: result.preimage };
+        },
+      };
+
+      const response = await fetch402(endpointUrl, {}, { wallet });
+      const body = await response.text();
+
+      setResponseBody(body);
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: "Payment confirmed",
+          status: "success",
+        });
+      }
+
+      addFlowStep({
+        fromWallet: "alice",
+        toWallet: "bob",
+        label: "Resource delivered",
+        direction: "right",
+        status: "success",
+      });
+
+      updateTransaction(txId, {
+        status: "success",
+        description: `402 fetch succeeded: ${protectedUrl}`,
+      });
+
+      // Refresh balances
+      const bobBalance = await bobClient.getBalance();
+      const bobBalanceSats = Math.floor(bobBalance.balance / 1000);
+      setWalletBalance("bob", bobBalanceSats);
+      addBalanceSnapshot({ walletId: "bob", balance: bobBalanceSats });
+
+      const aliceClient = getNWCClient("alice");
+      if (aliceClient) {
+        const aliceBalance = await aliceClient.getBalance();
+        const aliceBalanceSats = Math.floor(aliceBalance.balance / 1000);
+        setWalletBalance("alice", aliceBalanceSats);
+        addBalanceSnapshot({ walletId: "alice", balance: aliceBalanceSats });
+      }
+    } catch (err) {
+      console.error("402 fetch failed:", err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
+
+      updateTransaction(txId, {
+        status: "error",
+        description: `402 fetch failed: ${errorMessage}`,
+      });
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: `Payment failed: ${errorMessage}`,
+          status: "error",
+        });
+      } else {
+        updateFlowStep(requestFlowStepId, {
+          label: `Request failed: ${errorMessage}`,
+          status: "error",
+        });
+      }
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.bob.emoji}</span>
+          <span>Bob: Fetch Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Bob calls <code className="text-xs">fetch402</code> which
+          automatically handles the 402 response, pays the invoice, and retries
+          the request with proof of payment.
+        </p>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {responseBody !== null && (
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground flex items-center gap-1">
+              <ShieldCheck className="h-3.5 w-3.5 text-green-600" />
+              Response received
+            </label>
+            <div className="rounded-lg bg-muted p-3">
+              <pre className="text-xs whitespace-pre-wrap break-all leading-relaxed max-h-48 overflow-y-auto">
+                {responseBody.length > 1000
+                  ? responseBody.slice(0, 1000) + "\n…(truncated)"
+                  : responseBody}
+              </pre>
+            </div>
+          </div>
+        )}
+
+        <Button
+          onClick={handleFetch}
+          disabled={isFetching || !endpointUrl}
+          className="w-full"
+        >
+          {isFetching ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Fetching...
+            </>
+          ) : (
+            <>
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Fetch Resource
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/402/mpp-fetch.tsx
+++ b/src/components/402/mpp-fetch.tsx
@@ -1,0 +1,345 @@
+import { useState } from "react";
+import { Copy, Loader2, ShieldCheck } from "lucide-react";
+import { fetch402, Invoice } from "@getalby/lightning-tools";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useWalletStore, useTransactionStore } from "@/stores";
+import { WALLET_PERSONAS } from "@/types";
+
+const PROXY_BASE_URL = "https://402-proxy.albylabs.com/mpp";
+const DEFAULT_PROTECTED_URL = "https://example.com";
+const DEFAULT_PRICE_SATS = 1;
+
+export function MPPFetchScenario() {
+  const { areAllWalletsConnected } = useWalletStore();
+  const allConnected = areAllWalletsConnected(["alice", "bob"]);
+
+  const [protectedUrl, setProtectedUrl] = useState(DEFAULT_PROTECTED_URL);
+  const [priceSats, setPriceSats] = useState(DEFAULT_PRICE_SATS);
+
+  if (!allConnected) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <AlicePanel
+        protectedUrl={protectedUrl}
+        priceSats={priceSats}
+        onProtectedUrlChange={setProtectedUrl}
+        onPriceSatsChange={setPriceSats}
+      />
+      <BobPanel protectedUrl={protectedUrl} priceSats={priceSats} />
+    </div>
+  );
+}
+
+interface AlicePanelProps {
+  protectedUrl: string;
+  priceSats: number;
+  onProtectedUrlChange: (url: string) => void;
+  onPriceSatsChange: (sats: number) => void;
+}
+
+function AlicePanel({
+  protectedUrl,
+  priceSats,
+  onProtectedUrlChange,
+  onPriceSatsChange,
+}: AlicePanelProps) {
+  const { getWallet } = useWalletStore();
+  const aliceWallet = getWallet("alice");
+  const [copied, setCopied] = useState(false);
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleCopy = () => {
+    if (!endpointUrl) return;
+    navigator.clipboard.writeText(endpointUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.alice.emoji}</span>
+          <span>Alice: Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Alice's NWC connection is embedded in the endpoint URL. When Bob
+          fetches the resource, the proxy uses her wallet to create a Lightning
+          invoice and returns it via the{" "}
+          <code className="text-xs">Payment-Required</code> header.
+        </p>
+
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              Protected URL
+            </label>
+            <Input
+              value={protectedUrl}
+              onChange={(e) => onProtectedUrlChange(e.target.value)}
+              placeholder="https://example.com"
+              className="font-mono text-xs h-8"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground mr-2">
+              Price (sats)
+            </label>
+            <Input
+              type="number"
+              min={1}
+              value={priceSats}
+              onChange={(e) =>
+                onPriceSatsChange(Math.max(1, parseInt(e.target.value) || 1))
+              }
+              className="font-mono text-xs h-8 w-28"
+            />
+          </div>
+        </div>
+
+        {endpointUrl ? (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground">
+              402 Endpoint URL
+            </label>
+            <div className="relative rounded-lg bg-muted p-3 pr-10">
+              <p className="break-all font-mono text-xs leading-relaxed">
+                {endpointUrl}
+              </p>
+              <button
+                onClick={handleCopy}
+                className="absolute right-2 top-2 rounded p-1 hover:bg-background"
+                title="Copy URL"
+              >
+                <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            </div>
+            {copied && (
+              <p className="text-xs text-green-600 dark:text-green-400">
+                Copied to clipboard
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-yellow-50 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+            Alice's wallet is not connected.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface BobPanelProps {
+  protectedUrl: string;
+  priceSats: number;
+}
+
+function BobPanel({ protectedUrl, priceSats }: BobPanelProps) {
+  const [isFetching, setIsFetching] = useState(false);
+  const [responseBody, setResponseBody] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { getNWCClient, getWallet, setWalletBalance } = useWalletStore();
+  const {
+    addTransaction,
+    updateTransaction,
+    addFlowStep,
+    updateFlowStep,
+    addBalanceSnapshot,
+  } = useTransactionStore();
+
+  const aliceWallet = getWallet("alice");
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleFetch = async () => {
+    if (!endpointUrl) return;
+
+    const bobClient = getNWCClient("bob");
+    if (!bobClient) return;
+
+    setIsFetching(true);
+    setError(null);
+    setResponseBody(null);
+
+    const txId = addTransaction({
+      type: "payment_sent",
+      status: "pending",
+      fromWallet: "bob",
+      toWallet: "alice",
+      amount: 0,
+      description: `MPP fetch: ${protectedUrl}`,
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    const requestFlowStepId = addFlowStep({
+      fromWallet: "bob",
+      toWallet: "alice",
+      label: "Fetching resource...",
+      direction: "left",
+      status: "pending",
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    let payFlowStepId = "";
+
+    try {
+      const wallet = {
+        payInvoice: async (args: { invoice: string }) => {
+          const invoiceObj = new Invoice({ pr: args.invoice });
+          const amountSats = invoiceObj.satoshi ?? priceSats;
+
+          updateTransaction(txId, { amount: amountSats });
+
+          payFlowStepId = addFlowStep({
+            fromWallet: "bob",
+            toWallet: "alice",
+            label: `Paying ${amountSats} sat invoice...`,
+            direction: "left",
+            status: "pending",
+          });
+
+          updateFlowStep(requestFlowStepId, {
+            label: "402 received — paying invoice...",
+            direction: "right",
+            status: "success",
+          });
+
+          const result = await bobClient.payInvoice({ invoice: args.invoice });
+          return { preimage: result.preimage };
+        },
+      };
+
+      const response = await fetch402(endpointUrl, {}, { wallet });
+      const body = await response.text();
+
+      setResponseBody(body);
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: "Payment confirmed",
+          status: "success",
+        });
+      }
+
+      addFlowStep({
+        fromWallet: "alice",
+        toWallet: "bob",
+        label: "Resource delivered",
+        direction: "right",
+        status: "success",
+      });
+
+      updateTransaction(txId, {
+        status: "success",
+        description: `MPP fetch succeeded: ${protectedUrl}`,
+      });
+
+      // Refresh balances
+      const bobBalance = await bobClient.getBalance();
+      const bobBalanceSats = Math.floor(bobBalance.balance / 1000);
+      setWalletBalance("bob", bobBalanceSats);
+      addBalanceSnapshot({ walletId: "bob", balance: bobBalanceSats });
+
+      const aliceClient = getNWCClient("alice");
+      if (aliceClient) {
+        const aliceBalance = await aliceClient.getBalance();
+        const aliceBalanceSats = Math.floor(aliceBalance.balance / 1000);
+        setWalletBalance("alice", aliceBalanceSats);
+        addBalanceSnapshot({ walletId: "alice", balance: aliceBalanceSats });
+      }
+    } catch (err) {
+      console.error("MPP fetch failed:", err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
+
+      updateTransaction(txId, {
+        status: "error",
+        description: `MPP fetch failed: ${errorMessage}`,
+      });
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: `Payment failed: ${errorMessage}`,
+          status: "error",
+        });
+      } else {
+        updateFlowStep(requestFlowStepId, {
+          label: `Request failed: ${errorMessage}`,
+          status: "error",
+        });
+      }
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.bob.emoji}</span>
+          <span>Bob: Fetch Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Bob calls <code className="text-xs">fetch402</code> which detects the{" "}
+          <code className="text-xs">Payment-Required</code> header, pays the
+          invoice, and retries the request with a{" "}
+          <code className="text-xs">Payment</code> header containing the
+          preimage as proof.
+        </p>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {responseBody !== null && (
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground flex items-center gap-1">
+              <ShieldCheck className="h-3.5 w-3.5 text-green-600" />
+              Response received
+            </label>
+            <div className="rounded-lg bg-muted p-3">
+              <pre className="text-xs whitespace-pre-wrap break-all leading-relaxed max-h-48 overflow-y-auto">
+                {responseBody.length > 1000
+                  ? responseBody.slice(0, 1000) + "\n…(truncated)"
+                  : responseBody}
+              </pre>
+            </div>
+          </div>
+        )}
+
+        <Button
+          onClick={handleFetch}
+          disabled={isFetching || !endpointUrl}
+          className="w-full"
+        >
+          {isFetching ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Fetching...
+            </>
+          ) : (
+            <>
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Fetch Resource
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/402/x402-fetch.tsx
+++ b/src/components/402/x402-fetch.tsx
@@ -1,0 +1,342 @@
+import { useState } from "react";
+import { Copy, Loader2, ShieldCheck } from "lucide-react";
+import { fetch402, Invoice } from "@getalby/lightning-tools";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useWalletStore, useTransactionStore } from "@/stores";
+import { WALLET_PERSONAS } from "@/types";
+
+const PROXY_BASE_URL = "https://402-proxy.albylabs.com/x402";
+const DEFAULT_PROTECTED_URL = "https://example.com";
+const DEFAULT_PRICE_SATS = 1;
+
+export function X402FetchScenario() {
+  const { areAllWalletsConnected } = useWalletStore();
+  const allConnected = areAllWalletsConnected(["alice", "bob"]);
+
+  const [protectedUrl, setProtectedUrl] = useState(DEFAULT_PROTECTED_URL);
+  const [priceSats, setPriceSats] = useState(DEFAULT_PRICE_SATS);
+
+  if (!allConnected) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <AlicePanel
+        protectedUrl={protectedUrl}
+        priceSats={priceSats}
+        onProtectedUrlChange={setProtectedUrl}
+        onPriceSatsChange={setPriceSats}
+      />
+      <BobPanel protectedUrl={protectedUrl} priceSats={priceSats} />
+    </div>
+  );
+}
+
+interface AlicePanelProps {
+  protectedUrl: string;
+  priceSats: number;
+  onProtectedUrlChange: (url: string) => void;
+  onPriceSatsChange: (sats: number) => void;
+}
+
+function AlicePanel({
+  protectedUrl,
+  priceSats,
+  onProtectedUrlChange,
+  onPriceSatsChange,
+}: AlicePanelProps) {
+  const { getWallet } = useWalletStore();
+  const aliceWallet = getWallet("alice");
+  const [copied, setCopied] = useState(false);
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleCopy = () => {
+    if (!endpointUrl) return;
+    navigator.clipboard.writeText(endpointUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.alice.emoji}</span>
+          <span>Alice: Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Alice's NWC connection is registered with the x402 facilitator. When
+          Bob fetches the resource, the facilitator generates a Lightning
+          invoice on her behalf.
+        </p>
+
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              Protected URL
+            </label>
+            <Input
+              value={protectedUrl}
+              onChange={(e) => onProtectedUrlChange(e.target.value)}
+              placeholder="https://example.com"
+              className="font-mono text-xs h-8"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground mr-2">
+              Price (sats)
+            </label>
+            <Input
+              type="number"
+              min={1}
+              value={priceSats}
+              onChange={(e) =>
+                onPriceSatsChange(Math.max(1, parseInt(e.target.value) || 1))
+              }
+              className="font-mono text-xs h-8 w-28"
+            />
+          </div>
+        </div>
+
+        {endpointUrl ? (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground">
+              402 Endpoint URL
+            </label>
+            <div className="relative rounded-lg bg-muted p-3 pr-10">
+              <p className="break-all font-mono text-xs leading-relaxed">
+                {endpointUrl}
+              </p>
+              <button
+                onClick={handleCopy}
+                className="absolute right-2 top-2 rounded p-1 hover:bg-background"
+                title="Copy URL"
+              >
+                <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            </div>
+            {copied && (
+              <p className="text-xs text-green-600 dark:text-green-400">
+                Copied to clipboard
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-yellow-50 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+            Alice's wallet is not connected.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface BobPanelProps {
+  protectedUrl: string;
+  priceSats: number;
+}
+
+function BobPanel({ protectedUrl, priceSats }: BobPanelProps) {
+  const [isFetching, setIsFetching] = useState(false);
+  const [responseBody, setResponseBody] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { getNWCClient, getWallet, setWalletBalance } = useWalletStore();
+  const {
+    addTransaction,
+    updateTransaction,
+    addFlowStep,
+    updateFlowStep,
+    addBalanceSnapshot,
+  } = useTransactionStore();
+
+  const aliceWallet = getWallet("alice");
+
+  const endpointUrl = aliceWallet?.connectionString
+    ? `${PROXY_BASE_URL}?url=${encodeURIComponent(protectedUrl)}&nwc_url=${encodeURIComponent(aliceWallet.connectionString)}&amount=${priceSats}`
+    : null;
+
+  const handleFetch = async () => {
+    if (!endpointUrl) return;
+
+    const bobClient = getNWCClient("bob");
+    if (!bobClient) return;
+
+    setIsFetching(true);
+    setError(null);
+    setResponseBody(null);
+
+    const txId = addTransaction({
+      type: "payment_sent",
+      status: "pending",
+      fromWallet: "bob",
+      toWallet: "alice",
+      amount: 0,
+      description: `x402 fetch: ${protectedUrl}`,
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    const requestFlowStepId = addFlowStep({
+      fromWallet: "bob",
+      toWallet: "alice",
+      label: "Fetching resource...",
+      direction: "left",
+      status: "pending",
+      snippetIds: ["fetch-with-l402"],
+    });
+
+    let payFlowStepId = "";
+
+    try {
+      const wallet = {
+        payInvoice: async (args: { invoice: string }) => {
+          const invoiceObj = new Invoice({ pr: args.invoice });
+          const amountSats = invoiceObj.satoshi ?? priceSats;
+
+          updateTransaction(txId, { amount: amountSats });
+
+          payFlowStepId = addFlowStep({
+            fromWallet: "bob",
+            toWallet: "alice",
+            label: `Paying ${amountSats} sat invoice...`,
+            direction: "left",
+            status: "pending",
+          });
+
+          updateFlowStep(requestFlowStepId, {
+            label: "402 received — paying invoice...",
+            direction: "right",
+            status: "success",
+          });
+
+          const result = await bobClient.payInvoice({ invoice: args.invoice });
+          return { preimage: result.preimage };
+        },
+      };
+
+      const response = await fetch402(endpointUrl, {}, { wallet });
+      const body = await response.text();
+
+      setResponseBody(body);
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: "Payment confirmed",
+          status: "success",
+        });
+      }
+
+      addFlowStep({
+        fromWallet: "alice",
+        toWallet: "bob",
+        label: "Resource delivered",
+        direction: "right",
+        status: "success",
+      });
+
+      updateTransaction(txId, {
+        status: "success",
+        description: `x402 fetch succeeded: ${protectedUrl}`,
+      });
+
+      // Refresh balances
+      const bobBalance = await bobClient.getBalance();
+      const bobBalanceSats = Math.floor(bobBalance.balance / 1000);
+      setWalletBalance("bob", bobBalanceSats);
+      addBalanceSnapshot({ walletId: "bob", balance: bobBalanceSats });
+
+      const aliceClient = getNWCClient("alice");
+      if (aliceClient) {
+        const aliceBalance = await aliceClient.getBalance();
+        const aliceBalanceSats = Math.floor(aliceBalance.balance / 1000);
+        setWalletBalance("alice", aliceBalanceSats);
+        addBalanceSnapshot({ walletId: "alice", balance: aliceBalanceSats });
+      }
+    } catch (err) {
+      console.error("x402 fetch failed:", err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
+
+      updateTransaction(txId, {
+        status: "error",
+        description: `x402 fetch failed: ${errorMessage}`,
+      });
+
+      if (payFlowStepId) {
+        updateFlowStep(payFlowStepId, {
+          label: `Payment failed: ${errorMessage}`,
+          status: "error",
+        });
+      } else {
+        updateFlowStep(requestFlowStepId, {
+          label: `Request failed: ${errorMessage}`,
+          status: "error",
+        });
+      }
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span>{WALLET_PERSONAS.bob.emoji}</span>
+          <span>Bob: Fetch Protected Resource</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Bob calls <code className="text-xs">fetch402</code> which detects the{" "}
+          <code className="text-xs">PAYMENT-REQUIRED</code> header, pays the
+          invoice via the facilitator, and retries with a payment signature.
+        </p>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {responseBody !== null && (
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground flex items-center gap-1">
+              <ShieldCheck className="h-3.5 w-3.5 text-green-600" />
+              Response received
+            </label>
+            <div className="rounded-lg bg-muted p-3">
+              <pre className="text-xs whitespace-pre-wrap break-all leading-relaxed max-h-48 overflow-y-auto">
+                {responseBody.length > 1000
+                  ? responseBody.slice(0, 1000) + "\n…(truncated)"
+                  : responseBody}
+              </pre>
+            </div>
+          </div>
+        )}
+
+        <Button
+          onClick={handleFetch}
+          disabled={isFetching || !endpointUrl}
+          className="w-full"
+        >
+          {isFetching ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Fetching...
+            </>
+          ) : (
+            <>
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Fetch Resource
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -60,6 +60,7 @@ export function AppSidebar() {
   const regularScenarios = scenarios.filter(
     (s) => !s.section || s.section === "scenarios",
   );
+  const fourzerotwoScenarios = scenarios.filter((s) => s.section === "402");
   const bitcoinConnectScenarios = scenarios.filter(
     (s) => s.section === "bitcoin-connect",
   );
@@ -108,10 +109,35 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+        {/* 402 Section */}
+        {fourzerotwoScenarios.length > 0 && (
+          <SidebarGroup className="-mt-4">
+            <SidebarGroupLabel className="text-xs font-semibold tracking-widest text-muted-foreground">
+              402
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {fourzerotwoScenarios.map((scenario) => (
+                  <SidebarMenuItem key={scenario.id}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={scenarioId === scenario.id}
+                    >
+                      <Link to={`/${scenario.id}`}>
+                        <span>{scenario.icon}</span>
+                        <span>{scenario.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
         {/* Bitcoin Connect Section */}
         <SidebarGroup className="-mt-4">
           <SidebarGroupLabel className="-mb-1">
-            <div title="Bitcoin Connect: let bitcoin surf the web">
+            <div title="Bitcoin Connect: let bitcoin surf the web" className="pointer-events-none">
               <BitcoinConnectIcon className="size-20" />
             </div>
           </SidebarGroupLabel>

--- a/src/components/scenario-info.tsx
+++ b/src/components/scenario-info.tsx
@@ -70,6 +70,26 @@ export function ScenarioInfo() {
                         </ol>
                       </div>
                     )}
+                  {currentScenario.links &&
+                    currentScenario.links.length > 0 && (
+                      <div className="border-t pt-3">
+                        <h5 className="mb-2 font-medium">Learn more</h5>
+                        <ul className="space-y-1">
+                          {currentScenario.links.map((link, i) => (
+                            <li key={i}>
+                              <a
+                                href={link.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline dark:text-blue-400 text-xs"
+                              >
+                                {link.label}
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
                 </div>
               </PopoverContent>
             </Popover>

--- a/src/components/scenario-panel.tsx
+++ b/src/components/scenario-panel.tsx
@@ -21,7 +21,7 @@ import {
   PayButtonScenario,
   PaymentModalScenario,
 } from "./bitcoin-connect";
-import { L402FetchScenario, X402FetchScenario } from "./402";
+import { L402FetchScenario, X402FetchScenario, MPPFetchScenario } from "./402";
 
 export function ScenarioPanel() {
   const { currentScenario } = useScenarioStore();
@@ -67,6 +67,8 @@ export function ScenarioPanel() {
       return <L402FetchScenario />;
     case "x402-fetch":
       return <X402FetchScenario />;
+    case "mpp-fetch":
+      return <MPPFetchScenario />;
     default:
       return null;
   }

--- a/src/components/scenario-panel.tsx
+++ b/src/components/scenario-panel.tsx
@@ -21,6 +21,7 @@ import {
   PayButtonScenario,
   PaymentModalScenario,
 } from "./bitcoin-connect";
+import { L402FetchScenario, X402FetchScenario } from "./402";
 
 export function ScenarioPanel() {
   const { currentScenario } = useScenarioStore();
@@ -62,6 +63,10 @@ export function ScenarioPanel() {
       return <PayButtonScenario />;
     case "payment-modal":
       return <PaymentModalScenario />;
+    case "l402-fetch":
+      return <L402FetchScenario />;
+    case "x402-fetch":
+      return <X402FetchScenario />;
     default:
       return null;
   }

--- a/src/components/visualizations/code-snippets.tsx
+++ b/src/components/visualizations/code-snippets.tsx
@@ -12,6 +12,7 @@ import {
   Check,
   Play,
   Link,
+  ShieldCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CodeHighlight } from '@/components/ui/code-highlight';
@@ -36,6 +37,7 @@ const CATEGORY_ICONS: Record<SnippetCategory, React.ReactNode> = {
   fiat: <DollarSign className="h-4 w-4" />,
   advanced: <Code className="h-4 w-4" />,
   'bitcoin-connect': <Link className="h-4 w-4" />,
+  '402': <ShieldCheck className="h-4 w-4" />,
 };
 
 export function CodeSnippets() {

--- a/src/data/code-snippets.ts
+++ b/src/data/code-snippets.ts
@@ -796,6 +796,7 @@ console.log("Response:", body)
 // L402 utilities: https://github.com/getAlby/js-lightning-tools
 // x402 Facilitator: https://x402.albylabs.com
 // x402 Facilitator (GitHub): https://github.com/getAlby/x402-facilitator
+// MPP (Lightning Charge Draft): https://paymentauth.org/draft-lightning-charge-00
 // 402 Proxy (GitHub): https://github.com/getAlby/402-proxy`,
   },
   {

--- a/src/data/code-snippets.ts
+++ b/src/data/code-snippets.ts
@@ -8,7 +8,8 @@ export type SnippetCategory =
   | "lightning-address"
   | "fiat"
   | "advanced"
-  | "bitcoin-connect";
+  | "bitcoin-connect"
+  | "402";
 
 /**
  * Valid snippet IDs - use this type for type-safe snippet references
@@ -60,7 +61,9 @@ export type SnippetId =
   | "bc-launch-modal"
   | "bc-disconnect"
   | "bc-pay-button"
-  | "bc-launch-payment-modal";
+  | "bc-launch-payment-modal"
+  // 402
+  | "fetch-with-l402";
 
 export type CodeLanguage = "javascript" | "typescript" | "bash";
 
@@ -88,6 +91,7 @@ export const SNIPPET_CATEGORIES: {
   { id: "fiat", label: "Fiat Conversion", icon: "dollar-sign" },
   { id: "advanced", label: "Advanced", icon: "code" },
   { id: "bitcoin-connect", label: "Bitcoin Connect", icon: "link" },
+  { id: "402", label: "402", icon: "lock" },
 ];
 
 export const CODE_SNIPPETS: CodeSnippet[] = [
@@ -759,6 +763,40 @@ function CheckoutButton() {
   )
 }`,
     category: "bitcoin-connect",
+  },
+  // 402
+  {
+    id: "fetch-with-l402",
+    title: "fetch402",
+    description:
+      "Fetch a resource protected by HTTP 402 Payment Required. Automatically handles the payment challenge and retries with proof of payment. Works with L402, x402, and MPP protocols.",
+    category: "402",
+    code: `import { fetch402 } from "@getalby/lightning-tools"
+import { nwc } from "@getalby/sdk"
+
+const client = new nwc.NWCClient({
+  nostrWalletConnectUrl: "nostr+walletconnect://...",
+})
+
+// fetch402 automatically:
+// 1. Sends the request
+// 2. On 402, parses the payment challenge (WWW-Authenticate header)
+// 3. Pays the invoice using your wallet
+// 4. Retries the request with proof of payment (Authorization: L402 token:preimage)
+const response = await fetch402(
+  "https://paidendpoint.example.com",
+  {}, // standard fetch options (method, headers, body, etc.)
+  { wallet: client } // NWC client implements the Wallet interface directly
+)
+
+const body = await response.text()
+console.log("Response:", body)
+
+// Server-side resources:
+// L402 utilities: https://github.com/getAlby/js-lightning-tools
+// x402 Facilitator: https://x402.albylabs.com
+// x402 Facilitator (GitHub): https://github.com/getAlby/x402-facilitator
+// 402 Proxy (GitHub): https://github.com/getAlby/402-proxy`,
   },
   {
     id: "bc-launch-payment-modal",

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -908,6 +908,15 @@ The flow: Enter amount → select currency → see converted value in real time.
         url: "https://github.com/getAlby/402-proxy",
       },
     ],
+    prompts: [
+      {
+        title: "Paid Data Feed",
+        description:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the price and the total sats spent across calls.",
+        prompt:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the current price and the total sats spent across all calls.",
+      },
+    ],
   },
   {
     id: "x402-fetch",
@@ -957,6 +966,15 @@ The flow: Enter amount → select currency → see converted value in real time.
         url: "https://github.com/getAlby/402-proxy",
       },
     ],
+    prompts: [
+      {
+        title: "Paid Data Feed",
+        description:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the price and the total sats spent across calls.",
+        prompt:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the current price and the total sats spent across all calls.",
+      },
+    ],
   },
   {
     id: "mpp-fetch",
@@ -1004,6 +1022,15 @@ The flow: Enter amount → select currency → see converted value in real time.
       {
         label: "js-lightning-tools — 402 utilities (GitHub)",
         url: "https://github.com/getAlby/js-lightning-tools",
+      },
+    ],
+    prompts: [
+      {
+        title: "Paid Data Feed",
+        description:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the price and the total sats spent across calls.",
+        prompt:
+          "Write a React component that fetches real-time BTC price data from a pay-per-call API using fetch402 and an NWC wallet. Show the current price and the total sats spent across all calls.",
       },
     ],
   },

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -958,6 +958,55 @@ The flow: Enter amount → select currency → see converted value in real time.
       },
     ],
   },
+  {
+    id: "mpp-fetch",
+    title: "MPP Fetch",
+    description:
+      "Bob fetches a paid HTTP resource protected by MPP (Machine Payments Protocol). Alice's wallet handles invoice creation directly via NWC.",
+    education:
+      "MPP (Machine Payments Protocol) is a lightweight HTTP payment standard designed for machine-to-machine payments. When Bob requests a protected resource, the server responds with HTTP 402 and a Payment-Required header containing a Lightning invoice generated directly via Alice's NWC connection. The fetch402 helper pays the invoice and retries the request with a Payment header containing the preimage as proof of payment.",
+    icon: "🤖",
+    section: "402",
+    complexity: "simple",
+    requiredWallets: ["alice", "bob"],
+    snippetIds: ["fetch-with-l402"],
+    howItWorks: [
+      {
+        title: "Bob requests the resource",
+        description:
+          "Bob's client sends an HTTP GET to the MPP proxy endpoint (which has Alice's NWC URL embedded).",
+      },
+      {
+        title: "Server responds with 402",
+        description:
+          "The proxy generates a Lightning invoice via Alice's NWC connection and returns HTTP 402 with a Payment-Required header containing the invoice.",
+      },
+      {
+        title: "fetch402 pays automatically",
+        description:
+          "The fetch402 helper detects the Payment-Required header, pays the invoice using Bob's NWC wallet, and retries the request with a Payment header containing the preimage as proof.",
+      },
+      {
+        title: "Bob receives the resource",
+        description:
+          "The server verifies the preimage against the invoice and returns the protected content. Bob's balance decreases by the invoice amount, Alice's increases.",
+      },
+    ],
+    links: [
+      {
+        label: "Lightning Charge Draft (paymentauth.org)",
+        url: "https://paymentauth.org/draft-lightning-charge-00",
+      },
+      {
+        label: "402 Proxy — GitHub",
+        url: "https://github.com/getAlby/402-proxy",
+      },
+      {
+        label: "js-lightning-tools — 402 utilities (GitHub)",
+        url: "https://github.com/getAlby/js-lightning-tools",
+      },
+    ],
+  },
 ];
 
 const getComplexityIndex = (complexity: ScenarioComplexity) => {

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -863,6 +863,101 @@ The flow: Enter amount → select currency → see converted value in real time.
     requiredWallets: ["alice", "bob"],
     snippetIds: ["bc-init", "bc-launch-payment-modal"],
   },
+  // 402 Section
+  {
+    id: "l402-fetch",
+    title: "L402 Fetch",
+    description:
+      "Bob fetches a paid HTTP resource protected by the L402 protocol. Alice's wallet handles invoice creation.",
+    education:
+      "L402 (formerly LSAT) is a protocol combining HTTP 402 Payment Required with Lightning Network invoices. When Bob requests a protected resource, the server responds with a 402 status and a Lightning invoice. The fetch402 helper automatically pays the invoice using Bob's wallet and retries the request with a proof-of-payment header — all in one call.",
+    icon: "🔐",
+    section: "402",
+    complexity: "simple",
+    requiredWallets: ["alice", "bob"],
+    snippetIds: ["fetch-with-l402"],
+    howItWorks: [
+      {
+        title: "Bob requests the resource",
+        description:
+          "Bob's client sends an HTTP GET to the L402 proxy endpoint (which has Alice's NWC URL embedded).",
+      },
+      {
+        title: "Server responds with 402",
+        description:
+          "The proxy returns HTTP 402 with a WWW-Authenticate header containing a Lightning invoice generated via Alice's NWC connection.",
+      },
+      {
+        title: "fetch402 pays automatically",
+        description:
+          "The fetch402 helper intercepts the 402, pays the invoice using Bob's NWC wallet, and retries the request with an Authorization header containing the proof of payment.",
+      },
+      {
+        title: "Bob receives the resource",
+        description:
+          "The server verifies the payment and returns the protected content. Bob's balance decreases by the invoice amount, Alice's increases.",
+      },
+    ],
+    links: [
+      {
+        label: "js-lightning-tools — 402 utilities (GitHub)",
+        url: "https://github.com/getAlby/js-lightning-tools",
+      },
+      {
+        label: "402 Proxy — GitHub",
+        url: "https://github.com/getAlby/402-proxy",
+      },
+    ],
+  },
+  {
+    id: "x402-fetch",
+    title: "x402 Fetch",
+    description:
+      "Bob fetches a paid HTTP resource protected by the x402 protocol. A Lightning facilitator handles invoice generation and payment verification.",
+    education:
+      "x402 is an open HTTP payment standard that delegates invoice creation and payment verification to a trusted facilitator. When Bob requests a protected resource, the server returns a 402 with a PAYMENT-REQUIRED header containing a Lightning invoice sourced from the facilitator. The fetch402 helper pays the invoice and retries the request with a payment-signature header — the facilitator then confirms the payment and the server delivers the content.",
+    icon: "🔒",
+    section: "402",
+    complexity: "simple",
+    requiredWallets: ["alice", "bob"],
+    snippetIds: ["fetch-with-l402"],
+    howItWorks: [
+      {
+        title: "Bob requests the resource",
+        description:
+          "Bob's client sends an HTTP GET to the x402 proxy endpoint (which has Alice's NWC URL embedded).",
+      },
+      {
+        title: "Server responds with 402",
+        description:
+          "The proxy calls the x402 facilitator to generate a Lightning invoice for Alice, then returns HTTP 402 with a PAYMENT-REQUIRED header containing the invoice and payment requirements.",
+      },
+      {
+        title: "fetch402 pays automatically",
+        description:
+          "The fetch402 helper detects the PAYMENT-REQUIRED header, pays the invoice using Bob's NWC wallet, and retries the request with a payment-signature header containing proof of payment.",
+      },
+      {
+        title: "Facilitator verifies and server responds",
+        description:
+          "The proxy asks the facilitator to verify the payment. On success it proxies the protected content to Bob and settles the payment with the facilitator.",
+      },
+    ],
+    links: [
+      {
+        label: "x402 Facilitator (albylabs.com)",
+        url: "https://x402.albylabs.com",
+      },
+      {
+        label: "x402 Facilitator — GitHub",
+        url: "https://github.com/getAlby/x402-facilitator",
+      },
+      {
+        label: "402 Proxy — GitHub",
+        url: "https://github.com/getAlby/402-proxy",
+      },
+    ],
+  },
 ];
 
 const getComplexityIndex = (complexity: ScenarioComplexity) => {
@@ -882,8 +977,9 @@ const getComplexityIndex = (complexity: ScenarioComplexity) => {
 
 const getSectionIndex = (section?: ScenarioSection) => {
   if (!section || section === "scenarios") return 0;
-  if (section === "bitcoin-connect") return 1;
-  return 2;
+  if (section === "402") return 1;
+  if (section === "bitcoin-connect") return 2;
+  return 3;
 };
 
 export const scenarios = unorderedScenarios.sort((a, b) => {

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -2,7 +2,7 @@ import type { SnippetId } from "@/data/code-snippets";
 
 export type ScenarioComplexity = "simplest" | "simple" | "medium" | "advanced" | "expert";
 
-export type ScenarioSection = "scenarios" | "bitcoin-connect";
+export type ScenarioSection = "scenarios" | "402" | "bitcoin-connect";
 
 export interface ScenarioPrompt {
   title: string;
@@ -20,6 +20,7 @@ export interface Scenario {
   section?: ScenarioSection;
   requiredWallets?: string[];
   howItWorks?: { title: string; description: string }[];
+  links?: { label: string; url: string }[];
   prompts?: ScenarioPrompt[];
   snippetIds?: SnippetId[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,11 @@
   resolved "https://registry.yarnpkg.com/@getalby/lightning-tools/-/lightning-tools-6.1.0.tgz#558b90a83b961cb6aa760e62de69f5b5ceeb2fe9"
   integrity sha512-rGurar9X4Gm+9xwoNYS8s9YLK7ZYqvbqv4KbHLYV0LEeB0HxZHRgmxblGqg+fYfp6iiYHx+edIgUpt9rS3VwFw==
 
+"@getalby/lightning-tools@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@getalby/lightning-tools/-/lightning-tools-8.1.0.tgz#8aefcfba90fd43ccf87e6ccf8b426d21149222fe"
+  integrity sha512-P+wM1zNNwiSxA071jl2sNyPq/jfX02OSAEXIre/dL7P4dj0yC3YeyByI1/nKvPNqaFvXzHQn+7D9+Yo85aocRQ==
+
 "@getalby/sdk@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@getalby/sdk/-/sdk-6.0.2.tgz#4f3b987cc8a9da4fd755917a7de4499380114ee2"


### PR DESCRIPTION
TODO (could be moved to a follow-up PR):
- [x] Add MPP
- [x] Add an example prompt for 402 payments (client-side)

See also 402 updates to builder skill: https://github.com/getAlby/builder-skill/pull/39

<img width="2833" height="1557" alt="image" src="https://github.com/user-attachments/assets/616ce851-45e8-422f-a879-de0c1c5451f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new payment flow scenarios (L402 Fetch, X402 Fetch, MPP Fetch) demonstrating paid HTTP resource retrieval between two parties.
  * New 402 scenarios section in sidebar navigation.
  * Added resource links in scenario information panels for additional learning.

* **Documentation**
  * Added fetch402 code snippet with NWC integration examples.

* **Chores**
  * Updated lightning-tools dependency to a newer version.
  * Added typecheck script to development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->